### PR TITLE
F** added docker-compose, pyproject.toml, and pytest module;

### DIFF
--- a/scripts/gen_readme_table.py
+++ b/scripts/gen_readme_table.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import yaml, sys, pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+manifest = yaml.safe_load((ROOT / "portfolio.yaml").read_text())
+
+header = "| Name | Problem | Stack | Highlights | Status | Link |\n|---|---|---|---|---|---|\n"
+rows = []
+for p in manifest["projects"]:
+    rows.append(f"| {p['name']} | {p['problem']} | {', '.join(p['stack'])} | {', '.join(p['highlights'])} | {p['status']} | [{p['path']}](./{p['path']}) |")
+
+table = header + "\n".join(rows) + "\n"
+
+readme = (ROOT / "README.md").read_text().splitlines()
+out = []
+in_block = False
+for line in readme:
+    if line.strip() == "<!-- PROJECTS_TABLE_START -->":
+        in_block = True
+        out.append(line)
+        out.append(table)
+        continue
+    if line.strip() == "<!-- PROJECTS_TABLE_END -->":
+        in_block = False
+        out.append(line)
+        continue
+    if not in_block:
+        out.append(line)
+
+new_text = "\n".join(out) + "\n"
+if "--check" in sys.argv:
+    if new_text != (ROOT / "README.md").read_text():
+        print("README.md out of date. Run scripts/gen_readme_table.py", file=sys.stderr)
+        sys.exit(1)
+else:
+    (ROOT / "README.md").write_text(new_text)

--- a/ws-chat-fast/docker-compose.yml
+++ b/ws-chat-fast/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  api:
+    build: .
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    ports:
+      - "8000:8000"
+    environment:
+      - REDIS_URL=redis://redis:6379/0
+    depends_on:
+      - redis
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"

--- a/ws-chat-fast/pyproject.toml
+++ b/ws-chat-fast/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "ws-chat-fast"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "pydantic",
+    "redis",
+    "prometheus-client",
+    "websockets",
+    "httpx",
+]
+
+[tool.ruff]
+line-length = 100
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/ws-chat-fast/tests/test_ws.py
+++ b/ws-chat-fast/tests/test_ws.py
@@ -1,0 +1,11 @@
+import pytest
+from websockets import connect
+
+@pytest.mark.asyncio
+async def test_echo_message(live_server):
+    uri = f"ws://{live_server.host}:{live_server.port}/ws"
+    async with connect(uri) as websocket:
+        message = "Hello, WebSocket!"
+        await websocket.send(message)
+        response = await websocket.recv()
+        assert response == message


### PR DESCRIPTION
Given only the repo listing is visible publicly, here’s what’s likely (and what to fix).  ￼

4.1 ws-chat-fast (FastAPI/WebSocket demo)

Likely gaps:
•	No async tests, no load testing.
•	No docker-compose to run Redis/Broker (if used).
•	README probably thin; no architecture diagram/sequence.
•	No metrics/tracing.
